### PR TITLE
Update test-and-cut to use starter

### DIFF
--- a/actions/test-and-cut/action.yaml
+++ b/actions/test-and-cut/action.yaml
@@ -19,7 +19,7 @@ inputs:
   template:
     description: '--stack-config for testing'
     required: false
-    default: 'fireworks'
+    default: 'starter'
   llama_stack_only:
     description: 'Only cut a llama-stack release candidate'
     required: false

--- a/actions/test-and-cut/main.sh
+++ b/actions/test-and-cut/main.sh
@@ -17,7 +17,7 @@ fi
 GITHUB_TOKEN=${GITHUB_TOKEN:-}
 CUT_MODE=${CUT_MODE:-test-and-cut}
 LLAMA_STACK_ONLY=${LLAMA_STACK_ONLY:-false}
-TEMPLATE=${TEMPLATE:-fireworks}
+TEMPLATE=${TEMPLATE:-starter}
 
 source $(dirname $0)/../common.sh
 
@@ -152,6 +152,8 @@ test_docker() {
   # run the container in the background
   export LLAMA_STACK_PORT=8321
   docker run -d --name llama-stack-$TEMPLATE -p $LLAMA_STACK_PORT:$LLAMA_STACK_PORT \
+    -e ENABLE_FIREWORKS=fireworks \
+    -e ENABLE_TOGETHER=together \
     -e TOGETHER_API_KEY=$TOGETHER_API_KEY \
     -e FIREWORKS_API_KEY=$FIREWORKS_API_KEY \
     -e TAVILY_SEARCH_API_KEY=$TAVILY_SEARCH_API_KEY \


### PR DESCRIPTION
Since there are no fireworks / together distros, use starter instead. 