### PR TITLE
feat: Add nightly build publish workflow

### DIFF
--- a/.github/workflows/nightly-build-publish.yml
+++ b/.github/workflows/nightly-build-publish.yml
@@ -1,0 +1,31 @@
+name: Nightly Build and Publish
+
+on:
+#  schedule:
+#    - cron: "0 2 * * *"
+  workflow_dispatch:
+
+jobs:
+  nightly:
+    runs-on: ubuntu-latest
+    environment: nightly
+    permissions:
+      id-token: write  # Required for trusted publishing to PyPI/TestPyPI
+      contents: read
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Generate version
+      id: version
+      run: |
+        DATE=$(date +%Y%m%d)
+        VERSION="0.1.0.dev${DATE}"
+        echo "Generated nightly version: $VERSION"
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+    - uses: ./actions/nightly-build-publish
+      with:
+        version: ${{ steps.version.outputs.version }}
+        llama_stack_only: false
+        github_token: ${{ secrets.LLAMA_REPOS_PAT }}
+        npm_token: ${{ secrets.NPM_TOKEN }}

--- a/actions/nightly-build-publish/action.yaml
+++ b/actions/nightly-build-publish/action.yaml
@@ -1,0 +1,48 @@
+name: 'Nightly Test Build and Publish'
+description: 'Test, build and publish nightly packages to test registries for llama-stack, llama-stack-client-python, and llama-stack-client-typescript repos'
+inputs:
+  version:
+    description: 'Version of the package to publish'
+    required: true
+  github_token:
+    description: 'GitHub token for repo access'
+    required: true
+  npm_token:
+    description: 'NPM token for publishing'
+    required: true
+  llama_stack_only:
+    description: 'Only test and publish llama-stack (default: false)'
+    required: false
+    default: 'false'
+
+runs:
+  using: 'composite'
+  steps:
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+    - uses: astral-sh/setup-uv@v6
+      with:
+        python-version: '3.12'
+        enable-cache: false
+    - uses: actions/setup-node@v3
+      with:
+        node-version: '20'
+        registry-url: 'https://registry.npmjs.org'
+
+    - name: Configure Git
+      shell: bash
+      run: |
+        git config --global user.name "github-actions[bot]"
+        git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+    - name: Test Build and Publish
+      shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
+        GITHUB_TOKEN: ${{ inputs.github_token }}
+        LLAMA_STACK_ONLY: ${{ inputs.llama_stack_only }}
+        NPM_TOKEN: ${{ inputs.npm_token }}
+      run: |
+        chmod +x ${{ github.action_path }}/main.sh
+        ${{ github.action_path }}/main.sh

--- a/actions/nightly-build-publish/main.sh
+++ b/actions/nightly-build-publish/main.sh
@@ -1,0 +1,155 @@
+#!/bin/bash
+
+if [ -z "$VERSION" ]; then
+  echo "You must set the VERSION environment variable" >&2
+  exit 1
+fi
+
+if [ -z "$NPM_TOKEN" ]; then
+  echo "You must set the NPM_TOKEN environment variable" >&2
+  exit 1
+fi
+
+GITHUB_TOKEN=${GITHUB_TOKEN:-}
+LLAMA_STACK_ONLY=${LLAMA_STACK_ONLY:-false}
+
+source $(dirname $0)/../common.sh
+
+set -euo pipefail
+set -x
+
+is_truthy() {
+  case "$1" in
+  true | 1) return 0 ;;
+  false | 0) return 1 ;;
+  *) return 1 ;;
+  esac
+}
+
+setup_environment() {
+  echo "Setting up build environment..."
+
+  npm config set '//registry.npmjs.org/:_authToken' "$NPM_TOKEN"
+
+  npm install -g yarn
+
+  TMPDIR=$(mktemp -d)
+  cd $TMPDIR
+
+  uv venv -p python3.12
+  source .venv/bin/activate
+  uv pip install twine
+
+  install_dependencies  # Installs test dependencies
+}
+
+clone_and_prepare_repo() {
+  local repo=$1
+  local org=$(github_org $repo)
+
+  echo "Cloning and preparing $repo..."
+  git clone --depth 10 "https://x-access-token:${GITHUB_TOKEN}@github.com/$org/llama-$repo.git"
+  cd llama-$repo
+
+  echo "Checking out main branch for nightly build"
+  git checkout main
+
+  update_version_numbers $repo
+}
+
+update_version_numbers() {
+  local repo=$1
+
+  echo "Updating version numbers for $repo..."
+  if [ "$repo" == "stack-client-typescript" ]; then
+    echo "Updating TypeScript package version to $VERSION"
+    perl -pi -e "s/\"version\": \".*\"/\"version\": \"$VERSION\"/" package.json
+  else
+    echo "Updating Python package version to $VERSION"
+    perl -pi -e "s/^version = .*$/version = \"$VERSION\"/" pyproject.toml
+  fi
+}
+
+build_packages() {
+  local repo=$1
+
+  echo "Building packages for $repo..."
+
+  if [ "$repo" == "stack-client-typescript" ]; then
+    local VERSION_INFO=$(cat package.json | jq -r '.version')
+    echo "Building TypeScript package version: $VERSION_INFO"
+    npx yarn install
+    npx yarn build
+  else
+    local VERSION_INFO=$(cat pyproject.toml | grep version)
+    echo "Building Python package version: $VERSION_INFO"
+    uv build -q
+    uv pip install dist/*.whl
+  fi
+}
+
+test_packages() {
+  local repo=$1
+
+  # Basic CLI testing and Run integration tests for main stack package
+  # TODO: Add docker tests also
+  if [ "$repo" == "stack" ]; then
+    echo "Testing packages for $repo..."
+    test_llama_cli
+
+    echo "Running integration tests for main stack..."
+    llama stack build --distro starter --image-type venv
+    cd ..
+    run_integration_tests starter
+    cd llama-stack
+  fi
+}
+
+publish_packages() {
+  local repo=$1
+
+  echo "Publishing packages for $repo..."
+
+  if [ "$repo" == "stack-client-typescript" ]; then
+    echo "Publishing TypeScript package to npm"
+    cd dist
+    npx yarn publish --access public --tag nightly --registry https://registry.npmjs.org/
+    cd ..
+  else
+    echo "Publishing Python package to TestPyPI"
+    python -m twine upload \
+      --repository-url https://test.pypi.org/legacy/ \
+      --skip-existing \
+      dist/*.whl dist/*.tar.gz
+  fi
+}
+
+main() {
+  echo "Starting combined test, build and publish for nightly packages..."
+
+  # Repos to process
+  REPOS=(stack-client-python stack-client-typescript stack)
+
+  if is_truthy "$LLAMA_STACK_ONLY"; then
+    REPOS=(stack)
+  fi
+
+  setup_environment
+
+  for repo in "${REPOS[@]}"; do
+    echo "Processing $repo..."
+
+    clone_and_prepare_repo $repo
+    build_packages $repo
+    test_packages $repo
+    publish_packages $repo
+
+    echo "Completed processing $repo"
+    cd ..
+  done
+
+  echo "Nightly test, build and publish completed successfully!"
+}
+
+# Execute main
+main "$@"


### PR DESCRIPTION
Add nightly build publish github workflow for all three repos: llama-stack-typescript, llama-stack-client and llama-stack.

**Test Plan**
Tested on fork without publishing to TestPyPi and NPM
https://github.com/slekkala1/llama-stack-ops/actions/runs/17497937558